### PR TITLE
Get rid of warnings because of deprecated `#[deriving(x)]` constructs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,13 +66,13 @@ macro_rules! inspect(
 ///     _ => ()
 /// }
 /// ```
-#[deriving(Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct Mime(pub TopLevel, pub SubLevel, pub Vec<Param>);
 
 macro_rules! enoom {
     (pub enum $en:ident; $ext:ident; $($ty:ident, $text:expr;)*) => (
 
-        #[deriving(Clone)]
+        #[derive(Clone)]
         pub enum $en {
             $($ty),*,
             $ext(String)


### PR DESCRIPTION
Replace with `#[derive(x)]` syntax.