### PR TITLE
Generics over [Param]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,12 @@
 
 #![doc(html_root_url = "https://hyperium.github.io/mime.rs")]
 #![cfg_attr(test, deny(warnings))]
-#![cfg_attr(all(features = "nightly", test), feature(test))]
+#![cfg_attr(all(feature = "nightly", test), feature(test))]
 
 #[macro_use]
 extern crate log;
 
-#[cfg(features = "nightly")]
+#[cfg(feature = "nightly")]
 #[cfg(test)]
 extern crate test;
 
@@ -414,7 +414,7 @@ fn fmt_param(param: &Param, fmt: &mut fmt::Formatter) -> fmt::Result {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
-    #[cfg(features = "nightly")]
+    #[cfg(feature = "nightly")]
     use test::Bencher;
     use super::Mime;
 
@@ -437,15 +437,15 @@ mod tests {
     }
 
 
-    #[cfg(features = "nightly")]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_show(b: &mut Bencher) {
-        let mime = mime!(Text/Plain; Charset=Utf8, "foo"="bar");
+        let mime = mime!(Text/Plain; Charset=Utf8, ("foo")=("bar"));
         b.bytes = mime.to_string().as_bytes().len() as u64;
         b.iter(|| mime.to_string())
     }
 
-    #[cfg(features = "nightly")]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_from_str(b: &mut Bencher) {
         let s = "text/plain; charset=utf-8; foo=bar";


### PR DESCRIPTION
By being generic over the final property, parameters, these all become legal:

```rust
Mime(Text, Plain, vec![(Charset, Utf8)]);
Mime(Text, Plain, [(Charset, Utf8)]);
Mime(Text, Plain, &'static [(Charset, Utf8)]);
```

The PartialEq implementation has been modified to make sure all 3 of the above are `eq`. This leads way to the final commit: providing constants, since `[Param; N]` can be in a constant, where as `Vec<Param>` could not.

The last commit exports them as associated constants. It would be possible to export them as constants of the crate instead (and thus usable before Rust 1.1), but this follows precedent, that the constant is of type `Mime`, and should be part of `Mime`, similar to `Float::MIN` instead of `num::float::MIN`. It also allows the usage of these constants with only a single import, `mime::Mime`, instead of multiple.

This is technically a breaking change, since usage of `Mime` now implies `Mime<Vec<Param>>`. While this is preferred when the number of params are unknown, such as when parsing, that means that this won't work until hyper has been updated: `ContentType(Mime(Text, Plain, [(Charset, Plain)]))`.