### PR TITLE
Case sensitivity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,13 @@ mod tests {
             mime!(Text/Plain; Charset=Utf8, ("foo")=("bar")));
     }
 
+    #[test]
+    fn test_case_sensitive_values() {
+        assert_eq!(Mime::from_str("multipart/form-data; boundary=ABCDEFG").unwrap(),
+                   mime!(Multipart/FormData; Boundary=("ABCDEFG")));
+        assert_eq!(Mime::from_str("multipart/form-data; charset=BASE64; boundary=ABCDEFG").unwrap(),
+                   mime!(Multipart/FormData; Charset=("base64"), Boundary=("ABCDEFG")));
+    }
 
     #[cfg(feature = "nightly")]
     #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ enoom! {
     pub enum Attr;
     Ext;
     Charset, "charset";
+    Boundary, "boundary";
     Q, "q";
 }
 


### PR DESCRIPTION
This solution passes both `raw` and `ascii` into param_from_str(), and uses `ascii` for the attribute, but `raw` for the value.  This avoids creating new strings and then lowercasing them.

I'm not certain if *all* values should have their case preserved.  I only know that charset value should be lowercased, and boundary should not.  This branch only lowercases the value of charset (to be conservative).

fixes #24