### PR TITLE
Add Mime::get_param, and make string-like types more string-like

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,7 @@ impl FromStr for Mime {
         let mut params = vec![];
         // toplevel
         let mut start;
-        let mut top;
+        let top;
         loop {
             match inspect!("top iter", iter.next()) {
                 Some((0, c)) if is_restricted_name_first_char(c) => (),
@@ -245,7 +245,7 @@ impl FromStr for Mime {
         }
 
         // sublevel
-        let mut sub;
+        let sub;
         loop {
             match inspect!("sub iter", iter.next()) {
                 Some((i, c)) if i == start && is_restricted_name_first_char(c) => (),
@@ -286,7 +286,7 @@ impl FromStr for Mime {
 }
 
 fn param_from_str(raw: &str, ascii: &str, iter: &mut Enumerate<Chars>, mut start: usize) -> Option<(Param, usize)> {
-    let mut attr;
+    let attr;
     debug!("param_from_str, start={}", start);
     loop {
         match inspect!("attr iter", iter.next()) {
@@ -305,7 +305,7 @@ fn param_from_str(raw: &str, ascii: &str, iter: &mut Enumerate<Chars>, mut start
         }
     }
 
-    let mut value;
+    let value;
     // values must be restrict-name-char or "anything goes"
     let mut is_quoted = false;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,15 @@ macro_rules! enoom {
             $ext(String)
         }
 
+        impl $en {
+            pub fn as_str(&self) -> &str {
+                match *self {
+                    $($en::$ty => $text),*,
+                    $en::$ext(ref s) => &s
+                }
+            }
+        }
+
         impl PartialEq for $en {
             fn eq(&self, other: &$en) -> bool {
                 match (self, other) {
@@ -423,7 +432,7 @@ mod tests {
     use std::str::FromStr;
     #[cfg(feature = "nightly")]
     use test::Bencher;
-    use super::Mime;
+    use super::{Mime, Value};
 
     #[test]
     fn test_mime_show() {
@@ -449,6 +458,11 @@ mod tests {
                    mime!(Multipart/FormData; Boundary=("ABCDEFG")));
         assert_eq!(Mime::from_str("multipart/form-data; charset=BASE64; boundary=ABCDEFG").unwrap(),
                    mime!(Multipart/FormData; Charset=("base64"), Boundary=("ABCDEFG")));
+    }
+
+    #[test]
+    fn test_value_as_str() {
+        assert_eq!(Value::Utf8.as_str(), "utf-8");
     }
 
     #[cfg(feature = "nightly")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ macro_rules! enoom {
                 match (self, other) {
                     $( (&$en::$ty, &$en::$ty) => true ),*,
                     (&$en::$ext(ref a), &$en::$ext(ref b)) => a == b,
-                    _ => self.to_string() == other.to_string()
+                    _ => self.as_str() == other.as_str()
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,13 @@ macro_rules! enoom {
             }
         }
 
+        impl ::std::ops::Deref for $en {
+            type Target = str;
+            fn deref(&self) -> &str {
+                self.as_str()
+            }
+        }
+
         impl PartialEq for $en {
             fn eq(&self, other: &$en) -> bool {
                 match (self, other) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,42 @@ macro_rules! enoom {
             }
         }
 
+        impl PartialEq<String> for $en {
+            fn eq(&self, other: &String) -> bool {
+                self.as_str() == other
+            }
+        }
+
+        impl PartialEq<str> for $en {
+            fn eq(&self, other: &str) -> bool {
+                self.as_str() == other
+            }
+        }
+
+        impl<'a> PartialEq<&'a str> for $en {
+            fn eq(&self, other: &&'a str) -> bool {
+                self.as_str() == *other
+            }
+        }
+
+        impl PartialEq<$en> for String {
+            fn eq(&self, other: &$en) -> bool {
+                self == other.as_str()
+            }
+        }
+
+        impl PartialEq<$en> for str {
+            fn eq(&self, other: &$en) -> bool {
+                self == other.as_str()
+            }
+        }
+
+        impl<'a> PartialEq<$en> for &'a str {
+            fn eq(&self, other: &$en) -> bool {
+                *self == other.as_str()
+            }
+        }
+
         impl fmt::Display for $en {
             fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
                 fmt.write_str(match *self {
@@ -463,6 +499,12 @@ mod tests {
     #[test]
     fn test_value_as_str() {
         assert_eq!(Value::Utf8.as_str(), "utf-8");
+    }
+
+    #[test]
+    fn test_value_eq_str() {
+        assert_eq!(Value::Utf8, "utf-8");
+        assert_eq!("utf-8", Value::Utf8);
     }
 
     #[cfg(feature = "nightly")]


### PR DESCRIPTION
Untested example usage:

```rust
use hyper::{client, mime, header};
let response: client::Response = /* … */;
let encoding = response.headers.get::<header::ContentType>()
    .and_then(|header| header.get_param(mime::Attr::Charset))
    // Deref coercion to &str:
    .and_then(|charset| encoding::label::encoding_from_whatwg_label(charset))
    .unwrap_or(encoding::all::UTF_8);