### PR TITLE
Implement serde Serialize and Deserialize for Mime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ keywords = ["mime", "media-extensions", "media-types"]
 
 [dependencies]
 log = "*"
+serde = "^0.6"
+
+[dev_dependencies]
+serde_json = "*"
 
 [features]
 nightly = []


### PR DESCRIPTION
Nothing fancy here. Serializes via the Display trait. Deserializes via the
FromStr trait.

I have a downstream crate with a struct that I wish to serialize, but it has a field of type Mime.  Hence this PR.