### PR TITLE
Added JsonApi entry to SubLevel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,7 @@ enoom! {
     Json, "json";
     WwwFormUrlEncoded, "x-www-form-urlencoded";
     Msgpack, "msgpack";
+    JsonApi, "vnd.api+json";
 
     // multipart/*
     FormData, "form-data";


### PR DESCRIPTION
I assume we don't want a ton of entries in `SubLevel`; however, some crates - params, for example [1] - do treat `SubLevel::Json` in special ways, which should be similar to `JsonApi`, and having this entry would make life easier.

[1] https://github.com/iron/params/blob/master/src/lib.rs#L460