### PR TITLE
Add SubLevel::OctetStream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,7 @@ enoom! {
     Json, "json";
     WwwFormUrlEncoded, "x-www-form-urlencoded";
     Msgpack, "msgpack";
+    OctetStream, "octet-stream";
 
     // multipart/*
     FormData, "form-data";


### PR DESCRIPTION
I was surprised to find that `application/octet-stream` could not be represented by `Mime` without an allocation. It's kinda undesirable for [`mime_guess`](https://github.com/cybergeek94/mime_guess) where the aforementioned is the default Media Type assumed.