### PR TITLE
Use more conventional key name in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["mime", "media-extensions", "media-types"]
 log = "0.3"
 serde = { version = ">=0.7, <0.9", optional = true }
 
-[dev_dependencies]
+[dev-dependencies]
 serde_json = ">=0.7, <0.9"
 
 [dependencies.heapsize]


### PR DESCRIPTION
It is intended that `-` is used in multi-word Cargo.toml keys. `_` was historically accepted and is not going away, but let's use `-` just in case :)

See https://github.com/rust-lang/cargo/pull/3771